### PR TITLE
Ability to generate a JSON schema from struct values

### DIFF
--- a/fixtures/schema_by_value.json
+++ b/fixtures/schema_by_value.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/json-schema-by-value",
+  "$ref": "#/$defs/JSONSchemaByValue",
+  "$defs": {
+    "JSONSchemaByValue": {
+      "properties": {
+        "field1": {
+          "type": "string"
+        },
+        "field2": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "field1",
+        "field2"
+      ]
+    }
+  }
+}

--- a/fixtures/schema_by_value_pointer.json
+++ b/fixtures/schema_by_value_pointer.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema/json-schema-by-value",
+  "$ref": "#/$defs/JSONSchemaByValue",
+  "$defs": {
+    "JSONSchemaByValue": {
+      "properties": {
+        "field1": {
+          "type": "string"
+        },
+        "field2": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "field1",
+        "field2"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This PR allows users to use the original value in the `JSONSchema()`, `JSONSchemaExtend()`, `JSONSchemaAlias()`, `JSONSchema(func(any) *Schema)` and `JSONSchemaProperty()` interfaces. This allows users to dynamically build Schema's from the struct values.